### PR TITLE
data tests results in temp folder

### DIFF
--- a/build/datatest.ps1
+++ b/build/datatest.ps1
@@ -48,7 +48,7 @@ function Run-DataTests ($Projects, $entryPointMetadataKey){
             $argumentList = ($assemblies, '--teamcity=true')
         }
         'Jenkins' {
-            $ouputFile = Join-Path $Metadata.Common.Dir.TempPersist "DataTest.xml"
+            $ouputFile = Join-Path $Metadata.Common.Dir.Temp 'DataTest.xml'
             $argumentList = ($assemblies, "--nunit25-output=$ouputFile")
             Write-Host "Results (nunit2.5) will be saved as $ouputFile"
         }


### PR DESCRIPTION
Денис, там надо ещё поменять шаблон в Jenkins чтобы результаты тестов брались из папки temp а не из temp_persist.

В ERM был баг что надо очищать тесты, иначе они повторно импортируются, даже если билд упал.
Это изменения к нам пришло с апдейтом buildtools и результаты unit tests по умолчанию стали складываться в temp.

Поэтому они пропали из jenkins.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/2gis/nuclear-river-customer-intelligence/5)

<!-- Reviewable:end -->
